### PR TITLE
Backend/log scan modifications

### DIFF
--- a/server/src/controllers/occupancy-record/occupancy-record.ts
+++ b/server/src/controllers/occupancy-record/occupancy-record.ts
@@ -35,12 +35,6 @@ export const createOccupancyRecord = async (req: Request, res: Response) => {
     res.status(HttpStatus.BadRequest).json({ error: "No occupancy provided" });
     return;
   }
-  if (occupancy < 0) {
-    res
-      .status(HttpStatus.BadRequest)
-      .json({ error: "Invalid occupancy (cannot be < 0)" });
-    return;
-  }
 
   // Insert into database
   try {

--- a/server/src/jobs/log-scan.ts
+++ b/server/src/jobs/log-scan.ts
@@ -59,7 +59,9 @@ function processGymRecords(
 } {
   // Configuration constants
   const BUSY_THRESHOLD = 2000;
-  const EXIT_WEIGHT_FACTOR = 0.94;
+  // const EXIT_WEIGHT_FACTOR = 0.94;
+  // Note: Keeping at constant for now until proper factor is determined
+  const EXIT_WEIGHT_FACTOR = 1;
 
   // Calculate total entries and exits
   let totalEntries = 0;

--- a/server/src/jobs/log-scan.ts
+++ b/server/src/jobs/log-scan.ts
@@ -1,50 +1,121 @@
 import { CronJob } from "cron";
 import db from "@/models/database";
-import { OccupancyRecordType } from "@/models/types";
+import { OccupancyRecordType, LogRecordType } from "@/models/types";
 import {
   GYM_NAMES,
   OccupancyCollection,
+  GymName,
   timeRoundedToNearestMinute,
   getESTDate,
   dateFromClock,
   logger,
 } from "@/utils";
+
 /**
  * Initialize log scanner
  */
 export default function StartLogScanScheduler() {
   new CronJob(
-    "*/5 * * * *", // Every 5 minutes
-    logScanJob,
-    null, // onComplete
-    true, // start
-    "UTC" // timeZone
+      "*/5 * * * *", // Every 5 minutes
+      logScanJob,
+      null, // onComplete
+      true, // start
+      "UTC" // timeZone
   );
 }
 
 /**
- * Retrieves the most current log record from each gym,
- * calculates occupancy and inserts record into Current
- * collection at time rounded to nearest minute.
+ * Checks if the current time is after the evening threshold (8:00 PM)
+ * @param currentTime The current time in EST
+ * @returns True if it's after 8:00 PM
+ */
+function isEveningHours(currentTime: Date): boolean {
+  const today = getESTDate();
+  const eveningThreshold = dateFromClock(today, "20:00"); // 8:00 PM
+  return currentTime >= eveningThreshold;
+}
+
+/**
+ * Processes records for a gym to calculate occupancy with adjustments as needed
+ * @param records The log records for a gym
+ * @param gymName The name of the gym
+ * @param currentDateTime The current time
+ * @returns An occupancy record object and stats for logging
+ */
+function processGymRecords(
+    records: LogRecordType[],
+    gymName: GymName,
+    currentDateTime: Date
+): {
+  record: OccupancyRecordType;
+  stats: {
+    totalEntries: number;
+    totalExits: number;
+    adjustedExits: number;
+    occupancy: number;
+    adjustmentApplied: boolean;
+    exitWeightFactor: number;
+  }
+} {
+  // Configuration constants
+  const BUSY_THRESHOLD = 1000;
+  const EXIT_WEIGHT_FACTOR = 0.7;
+
+  // Calculate total entries and exits
+  let totalEntries = 0;
+  let totalExits = 0;
+  for (const record of records) {
+    totalEntries += record.entries;
+    totalExits += record.exits;
+  }
+
+  // Determine if adjustment should be applied
+  const isEvening = isEveningHours(currentDateTime);
+  const isBusy = (totalEntries + totalExits) > BUSY_THRESHOLD;
+  const shouldAdjust = isEvening && isBusy;
+
+  // Calculate occupancy
+  const adjustedExits = shouldAdjust ? Math.floor(totalExits * EXIT_WEIGHT_FACTOR) : totalExits;
+  const occupancy = totalEntries - adjustedExits;
+
+  return {
+    record: {
+      gym: gymName,
+      time: currentDateTime,
+      occupancy: occupancy
+    },
+    stats: {
+      totalEntries,
+      totalExits,
+      adjustedExits,
+      occupancy,
+      adjustmentApplied: shouldAdjust,
+      exitWeightFactor: EXIT_WEIGHT_FACTOR
+    }
+  };
+}
+
+/**
+ * Main job function that scans logs and calculates occupancy
  */
 export const logScanJob = async () => {
-  let currentTime = timeRoundedToNearestMinute(new Date());
-  const occupancyRecords: OccupancyRecordType[] = [];
+  // Set up time boundaries
+  const currentDateTime = getESTDate();
+  const startTime = dateFromClock(currentDateTime, "6:30");
+  const endTime = dateFromClock(currentDateTime, "23:59");
 
-  // Using the date time helpers to set start and end times in EST
-  const today = getESTDate();
-  const startTime = dateFromClock(today, "6:30");
-  const endTime = new Date(today);
-  endTime.setHours(23, 59, 59, 999);
-
-  // Only run the job if the current time is after 6:30 EST
-  const currentEST = getESTDate();
-  if (currentEST < startTime) {
-    logger.info(`Current time is before 6:30 AM EST. Skipping log scan.`);
+  // Check if we should run the job
+  if (currentDateTime < startTime || currentDateTime > endTime) {
+    logger.info("Log scan job skipped - outside of scheduled hours");
     return;
   }
 
+  // Process each gym
+  const occupancyRecords: OccupancyRecordType[] = [];
+  const roundedCurrentTime = timeRoundedToNearestMinute(currentDateTime);
+
   for (const gymName of GYM_NAMES) {
+    // Fetch records for this gym
     const records = await db.getLogRecords({
       gym: gymName,
       dateRange: {
@@ -53,32 +124,38 @@ export const logScanJob = async () => {
       },
     });
 
-    const occupancy = records.reduce(
-      (acc, record) => acc + (record.entries - record.exits),
-      0
-    );
-    if (occupancy < 0) {
-      logger.error(
-        `Negative occupancy (${occupancy}) recorded for ${gymName} at ${currentTime}`,
-        records
+    const { record, stats } = processGymRecords(records, gymName, roundedCurrentTime);
+
+    if (stats.occupancy < 0) {
+      logger.warn(
+          `Negative occupancy (${stats.occupancy}) calculated for ${gymName} at ${roundedCurrentTime} - ` +
+          `Entries: ${stats.totalEntries}, Exits: ${stats.totalExits}, Adjusted Exits: ${stats.adjustedExits}. ` +
+          `Setting to 0.`
       );
-      continue;
     }
-    occupancyRecords.push({
-      gym: gymName,
-      time: currentTime,
-      occupancy: occupancy,
-    });
+
+    if (stats.adjustmentApplied) {
+      logger.info(
+          `Applied busy evening adjustment (${stats.exitWeightFactor}x) to exits for ${gymName}. ` +
+          `Total entries: ${stats.totalEntries}, Total exits: ${stats.totalExits}, ` +
+          `Adjusted exits: ${stats.adjustedExits}, occupancy: ${stats.occupancy}, `
+      );
+    }
+
+    occupancyRecords.push(record);
   }
+
+  // Save records to database
   await db.insertOccupancyRecords(
-    occupancyRecords,
-    OccupancyCollection.Current
+      occupancyRecords,
+      OccupancyCollection.Current
   );
-  currentTime = timeRoundedToNearestMinute(new Date());
-  logger.info(`Log scan complete ${currentTime}`);
+
+  // Log completion
+  logger.info(`Log scan complete`);
   for (const record of occupancyRecords) {
     logger.info(
-      `Inserted occupancy record for ${record.gym} at ${record.time} with occupancy ${record.occupancy}`
+        `Inserted occupancy record for ${record.gym} at ${record.time} with occupancy ${record.occupancy}`
     );
   }
 };

--- a/server/src/models/types/schema/occupancy-schema.ts
+++ b/server/src/models/types/schema/occupancy-schema.ts
@@ -16,7 +16,7 @@ export const occupancyRecordSchema = new Schema({
     enum: GYM_NAMES,
   },
   time: { type: Date, required: true },
-  occupancy: { type: Number, required: true, min: 0 },
+  occupancy: { type: Number, required: true},
 });
 
 // Infer base types from schemas


### PR DESCRIPTION
Allow negative occupancy for visibility purposes (note that frontend will always bound between 0 and 100 anyways)

Update log scan to weigh exits more harshly during busy times
- Current trend where during very busy times occupancy counts beginning to run-off down to zero
- Bandaid solution for leakage through middle corridoor until new system is up
- Ran tests within mongodb playground to find reasonable thresholds